### PR TITLE
Handle simple types when converting to BigQuery schema

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,7 +87,7 @@ fn bigquery_{name}() {{
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }}
 "##,
             name = case.name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,8 @@ pub fn convert_bigquery_direct(input: &Value) -> Value {
         }
         _ => panic!(),
     };
-    json!({"foo": "bar"})
+    json!({
+        "type": dtype,
+        "mode": mode,
+    })
 }

--- a/tests/bigquery_allof.rs
+++ b/tests/bigquery_allof.rs
@@ -58,5 +58,5 @@ fn bigquery_test_allof_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }

--- a/tests/bigquery_array.rs
+++ b/tests/bigquery_array.rs
@@ -20,7 +20,7 @@ fn bigquery_test_array_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -61,5 +61,5 @@ fn bigquery_test_array_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }

--- a/tests/bigquery_atomic.rs
+++ b/tests/bigquery_atomic.rs
@@ -17,7 +17,7 @@ fn bigquery_test_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn bigquery_test_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn bigquery_test_incompatible_atomic_multitype() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -81,5 +81,5 @@ fn bigquery_test_incompatible_atomic_multitype_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }

--- a/tests/bigquery_map.rs
+++ b/tests/bigquery_map.rs
@@ -32,7 +32,7 @@ fn bigquery_test_map_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn bigquery_test_map_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn bigquery_test_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn bigquery_test_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn bigquery_test_incompatible_map_with_pattern_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -236,5 +236,5 @@ fn bigquery_test_incompatible_map_with_pattern_and_additional_properties() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }

--- a/tests/bigquery_object.rs
+++ b/tests/bigquery_object.rs
@@ -53,7 +53,7 @@ fn bigquery_test_object_with_atomics_is_sorted() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn bigquery_test_object_with_atomics_required() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -156,7 +156,7 @@ fn bigquery_test_object_with_atomics_required_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -206,5 +206,5 @@ fn bigquery_test_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }

--- a/tests/bigquery_oneof.rs
+++ b/tests/bigquery_oneof.rs
@@ -24,7 +24,7 @@ fn bigquery_test_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn bigquery_test_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn bigquery_test_incompatible_oneof_atomic() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn bigquery_test_incompatible_oneof_atomic_with_null() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn bigquery_test_oneof_object_with_atomics() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn bigquery_test_oneof_object_merge() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -309,7 +309,7 @@ fn bigquery_test_oneof_object_merge_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -339,7 +339,7 @@ fn bigquery_test_incompatible_oneof_atomic_and_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -374,7 +374,7 @@ fn bigquery_test_incompatible_oneof_object() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }
 
 #[test]
@@ -425,5 +425,5 @@ fn bigquery_test_incompatible_oneof_object_with_complex() {
     "#;
     let input: Value = serde_json::from_str(input_data).unwrap();
     let expected: Value = serde_json::from_str(expected_data).unwrap();
-    assert_eq!(expected, convert_bigquery_direct(&input, "root".to_string()));
+    assert_eq!(expected, convert_bigquery_direct(&input));
 }


### PR DESCRIPTION
This passes the `bigquery_atomic` test suite, run with the following command:

`cargo test --no-fail-fast bigquery`

This also runs all of the other tests, most of which are failing. 

---

The most significant hurdle here is working with the borrow checker. When recursively generating values, the values must be cloned/moved during the matching process in order to prevent a "use after free" or "variable out of scope" issue. My limited fluency with the standard library means that there are quite a few calls to `.to_owned()` and `.into()`.

https://doc.rust-lang.org/std/vec/struct.Vec.html
https://doc.rust-lang.org/rust-by-example/primitives/tuples.html
https://users.rust-lang.org/t/to-string-vs-to-owned-for-string-literals/1441
https://doc.rust-lang.org/std/collections/struct.HashSet.html