### PR TITLE
Add an abstract schema tree 

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,13 +1,53 @@
 use serde_json::json;
 use std::collections::HashMap;
 
-type Object = HashMap<String, Box<Field>>;
-type Array = Box<Field>;
+#[derive(Serialize, Deserialize, Debug)]
+struct Object {
+    fields: HashMap<String, Box<Field>>,
+}
+
+impl Object {
+    fn new() -> Self {
+        Object {
+            fields: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Array {
+    items: Box<Field>,
+}
+
+impl Array {
+    fn new(items: Field) -> Self {
+        Array {
+            items: Box::new(items),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 struct Map {
-    key: String,
+    key: Box<Field>,
     value: Box<Field>,
 }
 
+impl Map {
+    fn new(key: String, value: Field) -> Self {
+        Map {
+            key: Box::new(Field {
+                name: Some(key),
+                data_type: Type::String,
+                nullable: false,
+            }),
+            value: Box::new(value),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
 enum Type {
     Boolean,
     Integer,
@@ -19,32 +59,97 @@ enum Type {
     Json,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
 struct Field {
+    #[serde(rename = "type")]
     data_type: Type,
     name: Option<String>,
     nullable: bool,
 }
 
-impl Field {
-    fn new() -> Self {
-        Field {
-            data_type: Type::Object(HashMap::new()),
-            name: None,
-            nullable: false,
-        }
+#[test]
+fn test_serialize_object() {
+    let mut field = Field {
+        data_type: Type::Object(Object::new()),
+        name: Some("test_object".into()),
+        nullable: false,
+    };
+    if let Type::Object(object) = &mut field.data_type {
+        object.fields.insert(
+            "test_int".into(),
+            Box::new(Field {
+                data_type: Type::Integer,
+                name: Some("test_int".into()),
+                nullable: false,
+            }),
+        );
+        object.fields.insert(
+            "test_bool".into(),
+            Box::new(Field {
+                data_type: Type::Boolean,
+                name: Some("test_bool".into()),
+                nullable: false,
+            }),
+        );
     }
-
-    fn insert(&mut self, name: String, node: Field) {
-        if let Type::Object(values) = &mut self.data_type {
-            if values.contains_key(&name) {
-                panic!();
+    let expect = json!({
+        "name": "test_object",
+        "nullable": false,
+        "type": {
+            "object": {
+                "fields": {
+                    "test_int": {
+                        "name": "test_int",
+                        "type": "integer",
+                        "nullable": false
+                    },
+                    "test_bool": {
+                        "name": "test_bool",
+                        "type": "boolean",
+                        "nullable": false
+                    }
+                }
             }
-            values.insert(name, Box::new(node));
         }
-    }
+    });
+    assert_eq!(expect, json!(field))
 }
 
 #[test]
-fn test_object_insert() {
-    let node = Field::new();
+fn test_serialize_map() {
+    let atom = Field {
+        data_type: Type::Integer,
+        name: Some("test_value".into()),
+        nullable: false,
+    };
+    let field = Field {
+        data_type: Type::Map(Map::new("test_key".into(), atom)),
+        name: Some("test_map".into()),
+        nullable: true,
+    };
+    let expect = json!({
+        "name": "test_map",
+        "nullable": true,
+        "type": {
+            "map": {
+                "key": {
+                    "name": "test_key",
+                    "nullable": false,
+                    "type": "string",
+                },
+                "value": {
+                    "name": "test_value",
+                    "nullable": false,
+                    "type": "integer",
+                }
+            }
+        }
+    });
+    assert_eq!(expect, json!(field));
+}
+
+#[test]
+fn test_serialize_array() {
+    unimplemented!()
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,40 +72,40 @@ struct Field {
 fn test_serialize_object() {
     let mut field = Field {
         data_type: Type::Object(Object::new()),
-        name: Some("test_object".into()),
+        name: Some("test-object".into()),
         nullable: false,
     };
     if let Type::Object(object) = &mut field.data_type {
         object.fields.insert(
-            "test_int".into(),
+            "test-int".into(),
             Box::new(Field {
                 data_type: Type::Integer,
-                name: Some("test_int".into()),
+                name: Some("test-int".into()),
                 nullable: false,
             }),
         );
         object.fields.insert(
-            "test_bool".into(),
+            "test-bool".into(),
             Box::new(Field {
                 data_type: Type::Boolean,
-                name: Some("test_bool".into()),
+                name: Some("test-bool".into()),
                 nullable: false,
             }),
         );
     }
     let expect = json!({
-        "name": "test_object",
+        "name": "test-object",
         "nullable": false,
         "type": {
             "object": {
                 "fields": {
-                    "test_int": {
-                        "name": "test_int",
+                    "test-int": {
+                        "name": "test-int",
                         "type": "integer",
                         "nullable": false
                     },
-                    "test_bool": {
-                        "name": "test_bool",
+                    "test-bool": {
+                        "name": "test-bool",
                         "type": "boolean",
                         "nullable": false
                     }
@@ -120,26 +120,26 @@ fn test_serialize_object() {
 fn test_serialize_map() {
     let atom = Field {
         data_type: Type::Integer,
-        name: Some("test_value".into()),
+        name: Some("test-value".into()),
         nullable: false,
     };
     let field = Field {
-        data_type: Type::Map(Map::new("test_key".into(), atom)),
-        name: Some("test_map".into()),
+        data_type: Type::Map(Map::new("test-key".into(), atom)),
+        name: Some("test-map".into()),
         nullable: true,
     };
     let expect = json!({
-        "name": "test_map",
+        "name": "test-map",
         "nullable": true,
         "type": {
             "map": {
                 "key": {
-                    "name": "test_key",
+                    "name": "test-key",
                     "nullable": false,
                     "type": "string",
                 },
                 "value": {
-                    "name": "test_value",
+                    "name": "test-value",
                     "nullable": false,
                     "type": "integer",
                 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,7 +13,7 @@ enum Atom {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Object {
-    fields: HashMap<String, Box<Field>>,
+    fields: HashMap<String, Box<Tag>>,
 }
 
 impl Object {
@@ -26,11 +26,11 @@ impl Object {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Array {
-    items: Box<Field>,
+    items: Box<Tag>,
 }
 
 impl Array {
-    fn new(items: Field) -> Self {
+    fn new(items: Tag) -> Self {
         Array {
             items: Box::new(items),
         }
@@ -39,14 +39,14 @@ impl Array {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Map {
-    key: Box<Field>,
-    value: Box<Field>,
+    key: Box<Tag>,
+    value: Box<Tag>,
 }
 
 impl Map {
-    fn new(key: String, value: Field) -> Self {
+    fn new(key: String, value: Tag) -> Self {
         Map {
-            key: Box::new(Field {
+            key: Box::new(Tag {
                 name: Some(key),
                 data_type: Type::Atom(Atom::String),
                 nullable: false,
@@ -70,7 +70,7 @@ enum Type {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
-struct Field {
+struct Tag {
     #[serde(rename = "type")]
     data_type: Type,
     name: Option<String>,
@@ -79,7 +79,7 @@ struct Field {
 
 #[test]
 fn test_serialize_atom() {
-    let atom = Field {
+    let atom = Tag {
         data_type: Type::Atom(Atom::Integer),
         name: Some("test-int".into()),
         nullable: true,
@@ -94,7 +94,7 @@ fn test_serialize_atom() {
 
 #[test]
 fn test_serialize_object() {
-    let mut field = Field {
+    let mut field = Tag {
         data_type: Type::Object(Object::new()),
         name: Some("test-object".into()),
         nullable: false,
@@ -102,7 +102,7 @@ fn test_serialize_object() {
     if let Type::Object(object) = &mut field.data_type {
         object.fields.insert(
             "test-int".into(),
-            Box::new(Field {
+            Box::new(Tag {
                 data_type: Type::Atom(Atom::Integer),
                 name: Some("test-int".into()),
                 nullable: false,
@@ -110,7 +110,7 @@ fn test_serialize_object() {
         );
         object.fields.insert(
             "test-bool".into(),
-            Box::new(Field {
+            Box::new(Tag {
                 data_type: Type::Atom(Atom::Boolean),
                 name: Some("test-bool".into()),
                 nullable: false,
@@ -142,12 +142,12 @@ fn test_serialize_object() {
 
 #[test]
 fn test_serialize_map() {
-    let atom = Field {
+    let atom = Tag {
         data_type: Type::Atom(Atom::Integer),
         name: Some("test-value".into()),
         nullable: false,
     };
-    let field = Field {
+    let field = Tag {
         data_type: Type::Map(Map::new("test-key".into(), atom)),
         name: Some("test-map".into()),
         nullable: true,
@@ -176,12 +176,12 @@ fn test_serialize_map() {
 #[test]
 fn test_serialize_array() {
     // represent multi-set with nulls
-    let atom = Field {
+    let atom = Tag {
         data_type: Type::Atom(Atom::Integer),
         name: Some("test-int".into()),
         nullable: true,
     };
-    let field = Field {
+    let field = Tag {
         data_type: Type::Array(Array::new(atom)),
         name: Some("test-array".into()),
         nullable: false,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -59,6 +59,7 @@ impl Map {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 enum Type {
+    Null,
     Atom(Atom),
     Object(Object),
     Map(Map),
@@ -75,6 +76,21 @@ struct Tag {
     data_type: Type,
     name: Option<String>,
     nullable: bool,
+}
+
+#[test]
+fn test_serialize_null() {
+    let null_tag = Tag {
+        data_type: Type::Null,
+        name: None,
+        nullable: false,
+    };
+    let expect = json!({
+        "type": "null",
+        "name": null,
+        "nullable": false,
+    });
+    assert_eq!(expect, json!(null_tag))
 }
 
 #[test]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,50 @@
+use serde_json::json;
+use std::collections::HashMap;
+
+type Object = HashMap<String, Box<Field>>;
+type Array = Box<Field>;
+struct Map {
+    key: String,
+    value: Box<Field>,
+}
+
+enum Type {
+    Boolean,
+    Integer,
+    Number,
+    String,
+    Object(Object),
+    Map(Map),
+    Array(Array),
+    Json,
+}
+
+struct Field {
+    data_type: Type,
+    name: Option<String>,
+    nullable: bool,
+}
+
+impl Field {
+    fn new() -> Self {
+        Field {
+            data_type: Type::Object(HashMap::new()),
+            name: None,
+            nullable: false,
+        }
+    }
+
+    fn insert(&mut self, name: String, node: Field) {
+        if let Type::Object(values) = &mut self.data_type {
+            if values.contains_key(&name) {
+                panic!();
+            }
+            values.insert(name, Box::new(node));
+        }
+    }
+}
+
+#[test]
+fn test_object_insert() {
+    let node = Field::new();
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -175,5 +175,29 @@ fn test_serialize_map() {
 
 #[test]
 fn test_serialize_array() {
-    unimplemented!()
+    // represent multi-set with nulls
+    let atom = Field {
+        data_type: Type::Atom(Atom::Integer),
+        name: Some("test-int".into()),
+        nullable: true,
+    };
+    let field = Field {
+        data_type: Type::Array(Array::new(atom)),
+        name: Some("test-array".into()),
+        nullable: false,
+    };
+    let expect = json!({
+        "type": {
+            "array": {
+                "items": {
+                    "name": "test-int",
+                    "type": {"atom": "integer"},
+                    "nullable": true,
+                }
+            }
+        },
+        "name": "test-array",
+        "nullable": false
+    });
+    assert_eq!(expect, json!(field))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,12 +242,7 @@ pub fn convert_bigquery(input: &Value) -> Value {
             Some(properties) => handle_record(properties, json_type.as_bq_mode(), input),
             None => handle_map(input),
         },
-        JSONSchemaKind::Array => {
-            let mut field: Value = convert_bigquery(&input["items"]);
-            let object = field.as_object_mut().unwrap();
-            object.insert("mode".to_string(), json!("REPEATED"));
-            json!(object)
-        }
+        JSONSchemaKind::Array => handle_array(input),
         JSONSchemaKind::AllOf => unimplemented!(),
         JSONSchemaKind::OneOf => handle_oneof(&input["oneOf"].as_array().unwrap()),
         _ => json!({
@@ -322,6 +317,13 @@ fn handle_map(input: &Value) -> Value {
             value,
         ]
     })
+}
+
+fn handle_array(input: &Value) -> Value {
+    let mut field: Value = convert_bigquery(&input["items"]);
+    let object = field.as_object_mut().unwrap();
+    object.insert("mode".to_string(), json!("REPEATED"));
+    json!(object)
 }
 
 // Resolve the output of oneOf by finding a super-set of the schemas. This defaults to STRING otherwise.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
+mod ast;
+
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ extern crate converter;
 use clap::{App, Arg};
 use serde_json::Value;
 use std::fs::File;
-use std::io::{BufReader};
+use std::io::BufReader;
 
 fn main() {
     let matches = App::new("jst")


### PR DESCRIPTION
This adds an intermediate AST to transform into and from. This captures enough information to be useful for constructing both avro and bigquery schemas. 

There are some other changes that are tagging along due to refactoring:

* A change caught by `cargo fmt`
* Minor clean-up in `convert_bigquery`