### PR TITLE
Add a grammar and serde for bigquery

### DIFF
--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -39,7 +39,7 @@ pub struct Record {
     fields: HashMap<String, Box<Tag>>,
 }
 
-// See: https://cloud.google.com/bigquery/docs/schemas#standard_sql_data_types
+/// See: https://cloud.google.com/bigquery/docs/schemas#standard_sql_data_types
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub struct Tag {
@@ -59,13 +59,6 @@ mod fields_as_vec {
     use std::collections::HashMap;
     use std::iter::FromIterator;
 
-    // The signature of a serialize_with function must follow the pattern:
-    //
-    //    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
-    //    where
-    //        S: Serializer
-    //
-    // although it may also be generic over the input types T.
     pub fn serialize<S>(map: &HashMap<String, Box<Tag>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -77,13 +70,6 @@ mod fields_as_vec {
         seq.end()
     }
 
-    // The signature of a deserialize_with function must follow the pattern:
-    //
-    //    fn deserialize<'de, D>(D) -> Result<T, D::Error>
-    //    where
-    //        D: Deserializer<'de>
-    //
-    // although it may also be generic over the output types T.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Box<Tag>>, D::Error>
     where
         D: Deserializer<'de>,

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,6 +1,24 @@
+use std::collections::HashMap;
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
-enum Mode {
+pub enum Atom {
+    Int64,
+    Numeric,
+    Float64,
+    Bool,
+    String,
+    Bytes,
+    Date,
+    Datetime,
+    Geography,
+    Time,
+    Timestamp,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Mode {
     Nullable,
     Required,
     Repeated,
@@ -8,20 +26,89 @@ enum Mode {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "UPPERCASE")]
-enum Type {
-    Null,
-    Boolean,
-    Integer,
-    Float,
+pub enum Type {
+    Atom(Atom),
+    // Array(Tag)
+    // Struct
     Record(Record),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct Record {
+pub struct Record {
+    #[serde(with = "fields_as_vec")]
+    fields: HashMap<String, Box<Tag>>,
+}
+
+// See: https://cloud.google.com/bigquery/docs/schemas#standard_sql_data_types
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub struct Tag {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(flatten)]
     #[serde(rename = "type")]
     data_type: Box<Type>,
-    fields: Vec<Box<Type>>,
     mode: Mode,
+}
+
+// See: https://serde.rs/custom-date-format.html#date-in-a-custom-format
+mod fields_as_vec {
+    use super::{Record, Tag};
+    use serde::ser::{self, SerializeSeq, Serializer};
+    use serde::{Deserialize, Deserializer};
+    use std::collections::HashMap;
+    use std::iter::FromIterator;
+
+    // The signature of a serialize_with function must follow the pattern:
+    //
+    //    fn serialize<S>(&T, S) -> Result<S::Ok, S::Error>
+    //    where
+    //        S: Serializer
+    //
+    // although it may also be generic over the input types T.
+    pub fn serialize<S>(map: &HashMap<String, Box<Tag>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(map.len()))?;
+        for (_, element) in map {
+            seq.serialize_element(element)?;
+        }
+        seq.end()
+    }
+
+    // The signature of a deserialize_with function must follow the pattern:
+    //
+    //    fn deserialize<'de, D>(D) -> Result<T, D::Error>
+    //    where
+    //        D: Deserializer<'de>
+    //
+    // although it may also be generic over the output types T.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Box<Tag>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Vec<Box<Tag>> = Vec::deserialize(deserializer)?;
+        let map = HashMap::<String, Box<Tag>>::from_iter(s.into_iter().map(|record| {
+            let name: String = (*record).name.clone().unwrap();
+            (name, record)
+        }));
+        Ok(map)
+    }
+}
+
+use serde_json::json;
+
+#[test]
+fn test_serialize_record() {
+    let record = Tag {
+        name: None,
+        data_type: Box::new(Type::Atom(Atom::Bool)),
+        mode: Mode::Nullable,
+    };
+    let expect = json!({
+        "type": "BOOL",
+        "mode": "NULLABLE",
+    });
+    assert_eq!(expect, json!(record))
 }

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,0 +1,27 @@
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+enum Mode {
+    Nullable,
+    Required,
+    Repeated,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+enum Type {
+    Null,
+    Boolean,
+    Integer,
+    Float,
+    Record(Record),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Record {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(rename = "type")]
+    data_type: Box<Type>,
+    fields: Vec<Box<Type>>,
+    mode: Mode,
+}

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,7 +1,9 @@
+use serde::de::{self, Deserialize, Deserializer};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "UPPERCASE")]
+#[serde(rename_all = "UPPERCASE", tag = "type")]
 pub enum Atom {
     Int64,
     Numeric,
@@ -24,13 +26,42 @@ pub enum Mode {
     Repeated,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "UPPERCASE")]
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "UPPERCASE", tag = "type")]
 pub enum Type {
     Atom(Atom),
     // Array(Tag)
     // Struct
     Record(Record),
+}
+
+impl<'de> Deserialize<'de> for Type {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "UPPERCASE", tag = "type")]
+        enum TypeHelper {
+            Record,
+        };
+
+        let v = Value::deserialize(deserializer)?;
+
+        // Try to deserialize the type as an atom first
+        if let Ok(atom) = Atom::deserialize(&v) {
+            return Ok(Type::Atom(atom));
+        } else if let Ok(data_type) = TypeHelper::deserialize(&v) {
+            return match data_type {
+                TypeHelper::Record => {
+                    let record = Record::deserialize(&v).map_err(de::Error::custom)?;
+                    Ok(Type::Record(record))
+                }
+            };
+        } else {
+            return Err(de::Error::custom("Error deserializing type!"));
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -86,8 +117,8 @@ mod fields_as_vec {
 use serde_json::json;
 
 #[test]
-fn test_serialize_record() {
-    let record = Tag {
+fn test_serialize_atom() {
+    let atom = Tag {
         name: None,
         data_type: Box::new(Type::Atom(Atom::Bool)),
         mode: Mode::Nullable,
@@ -96,5 +127,166 @@ fn test_serialize_record() {
         "type": "BOOL",
         "mode": "NULLABLE",
     });
-    assert_eq!(expect, json!(record))
+    assert_eq!(expect, json!(atom))
+}
+
+#[test]
+fn test_deserialize_atom() {
+    let atom: Tag = serde_json::from_value(json!({
+        "name": "test-int",
+        "mode": "REPEATED",
+        "type": "INT64"
+    }))
+    .unwrap();
+
+    match atom.name {
+        Some(name) => assert_eq!(name, "test-int"),
+        _ => panic!(),
+    };
+    match *atom.data_type {
+        Type::Atom(Atom::Int64) => (),
+        _ => panic!(),
+    };
+    match atom.mode {
+        Mode::Repeated => (),
+        _ => panic!(),
+    };
+}
+
+#[test]
+fn test_serialize_record() {
+    let atom = Tag {
+        name: Some("test-int".into()),
+        data_type: Box::new(Type::Atom(Atom::Int64)),
+        mode: Mode::Nullable,
+    };
+
+    let mut record = Record {
+        fields: HashMap::new(),
+    };
+    record.fields.insert("test-int".into(), Box::new(atom));
+
+    let root = Tag {
+        name: None,
+        data_type: Box::new(Type::Record(record)),
+        mode: Mode::Nullable,
+    };
+
+    let expect = json!({
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [{
+            "name": "test-int",
+            "type": "INT64",
+            "mode": "NULLABLE"
+        }]
+    });
+
+    assert_eq!(expect, json!(root))
+}
+
+#[test]
+fn test_deserialize_record() {
+    let record: Tag = serde_json::from_value(json!({
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [{
+            "name": "test-int",
+            "type": "INT64",
+            "mode": "NULLABLE"
+        }]
+    }))
+    .unwrap();
+
+    let test_int = match &*record.data_type {
+        Type::Record(record) => record.fields.get("test-int").unwrap(),
+        _ => panic!(),
+    };
+    match *test_int.data_type {
+        Type::Atom(Atom::Int64) => (),
+        _ => panic!(),
+    };
+}
+
+#[test]
+fn test_serialize_nested_record() {
+    let atom = Tag {
+        name: Some("test-int".into()),
+        data_type: Box::new(Type::Atom(Atom::Int64)),
+        mode: Mode::Nullable,
+    };
+
+    let mut record_b = Record {
+        fields: HashMap::new(),
+    };
+    record_b.fields.insert("test-int".into(), Box::new(atom));
+
+    let tag_b = Tag {
+        name: Some("test-record-b".into()),
+        data_type: Box::new(Type::Record(record_b)),
+        mode: Mode::Nullable,
+    };
+
+    let mut record_a = Record {
+        fields: HashMap::new(),
+    };
+    record_a
+        .fields
+        .insert("test-record-b".into(), Box::new(tag_b));
+
+    let root = Tag {
+        name: Some("test-record-a".into()),
+        data_type: Box::new(Type::Record(record_a)),
+        mode: Mode::Nullable,
+    };
+
+    let expect = json!({
+        "name": "test-record-a",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [{
+            "name": "test-record-b",
+            "type": "RECORD",
+            "fields": [{
+                "name": "test-int",
+                "type": "INT64",
+                "mode": "NULLABLE"
+            }],
+            "mode": "NULLABLE"
+        }]
+    });
+
+    assert_eq!(expect, json!(root))
+}
+
+#[test]
+fn test_deserialize_nested_record() {
+    let data = json!({
+        "name": "test-record-a",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [{
+            "name": "test-record-b",
+            "type": "RECORD",
+            "fields": [{
+                "name": "test-int",
+                "type": "INT64",
+                "mode": "NULLABLE"
+            }],
+            "mode": "NULLABLE"
+        }]
+    });
+    let record_a: Tag = serde_json::from_value(data).unwrap();
+    let record_b = match &*record_a.data_type {
+        Type::Record(record) => record.fields.get("test-record-b").unwrap(),
+        _ => panic!(),
+    };
+    let test_int = match &*record_b.data_type {
+        Type::Record(record) => record.fields.get("test-int").unwrap(),
+        _ => panic!(),
+    };
+    match *test_int.data_type {
+        Type::Atom(Atom::Int64) => (),
+        _ => panic!(),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate serde;
 extern crate serde_json;
 
 mod ast;
+mod bigquery;
 
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet, VecDeque};


### PR DESCRIPTION
This adds a grammar for BigQuery. There are a couple noteworthy bits in this file.

* Using `#[serde(tag="type")]` on all enums does the correct thing when serializing. This saved time writing a custom serializer.
* The inverse is not true, so there is a custom deserializer for the `Type` enum. This is to handle the case `{"type": "INT64"}` and the ilk -- this is actually a `Type::Atom(Atom::Int64)`. The deserializer first tries to deserialize as an atom, and then matches against the other types.
* There is a custom serializer/deserializer for the `Record` struct. For ergonomics, I've treated the BigQuery field as a HashMap instead of a Vector. This assumption breaks if the type does not have a name...

