### PR TITLE
Add grammar for JSONSchema

### DIFF
--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -61,7 +61,7 @@ struct Tag {
     #[serde(skip_serializing_if = "Option::is_none")]
     all_of: Option<AllOf>,
     #[serde(flatten)]
-    extra: Option<HashMap<String, Value>>,
+    extra: HashMap<String, Value>,
 }
 
 struct JSONSchema {
@@ -96,7 +96,8 @@ fn test_deserialize_type_null() {
         "type": "null"
     });
     let schema: Tag = serde_json::from_value(data).unwrap();
-    assert_eq!(schema.data_type.as_str().unwrap(), "null")
+    assert_eq!(schema.data_type.as_str().unwrap(), "null");
+    assert!(schema.extra.is_empty());
 }
 
 #[test]
@@ -216,4 +217,13 @@ fn test_deserialize_type_all_of() {
     assert_eq!(all_of.len(), 2);
     assert_eq!(all_of[0].data_type, json!("integer"));
     assert_eq!(all_of[1].data_type, json!("null"));
+}
+
+#[test]
+fn test_deserialize_extras() {
+    let data = json!({
+        "meta": "hello world!"
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    assert_eq!(schema.extra["meta"], json!("hello world!"))
 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -32,6 +32,8 @@ struct Object {
     additional_properties: Option<AdditionalProperties>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pattern_properties: Option<Box<Tag>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    required: Option<Vec<String>>,
 }
 
 /// Represent an array of subschemas. This is also known as a `schemaArray`.
@@ -107,13 +109,15 @@ fn test_deserialize_type_object() {
         "properties": {
             "test-int": {"type": "integer"},
             "test-null": {"type": "null"}
-        }
+        },
+        "required": ["test-int"]
     });
     let schema: Tag = serde_json::from_value(data).unwrap();
     let props = schema.object.properties.unwrap();
     assert_eq!(props.len(), 2);
     let test_int = props.get("test-int").unwrap();
     assert_eq!(test_int.data_type, json!("integer"));
+    assert_eq!(schema.object.required.unwrap(), vec!["test-int"]);
 }
 
 #[test]

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -1,6 +1,9 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// The type enumeration does not contain any data and is used to determine
+/// available fields in the flattened tag. In JSONSchema parlance, these are
+/// known as `simpleTypes`.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 enum Type {
@@ -31,26 +34,28 @@ struct Object {
     pattern_properties: Option<Box<Tag>>,
 }
 
-/// Represent an array of subschemas
+/// Represent an array of subschemas. This is also known as a `schemaArray`.
 type TagArray = Vec<Box<Tag>>;
 type OneOf = TagArray;
 type AllOf = TagArray;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct Array {
+    // Using Option<TagArray> would support tuple validation
     #[serde(skip_serializing_if = "Option::is_none")]
-    items: Option<TagArray>,
+    items: Option<Box<Tag>>,
 }
 
+/// Container for the main body of the schema.
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase", tag = "type")]
 struct Tag {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     data_type: Value,
     #[serde(flatten)]
     object: Object,
     #[serde(flatten)]
-    items: Array,
+    array: Array,
     #[serde(skip_serializing_if = "Option::is_none")]
     one_of: Option<OneOf>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,7 +64,7 @@ struct Tag {
     extra: Option<HashMap<String, Value>>,
 }
 
-pub struct JSONSchema {
+struct JSONSchema {
     data: Tag,
 }
 
@@ -96,20 +101,119 @@ fn test_deserialize_type_null() {
 
 #[test]
 fn test_deserialize_type_object() {
-    panic!()
+    let data_true = json!({
+        "type": "object",
+        "additionalProperties": true
+    });
+    if let Ok(schema) = serde_json::from_value::<Tag>(data_true) {
+        match schema.object.additional_properties {
+            Some(AdditionalProperties::True) => (),
+            _ => panic!(),
+        }
+    };
+    let data_false = json!({
+        "type": "object",
+        "additionalProperties": false
+    });
+    if let Ok(schema) = serde_json::from_value::<Tag>(data_false) {
+        match schema.object.additional_properties {
+            Some(AdditionalProperties::False) => (),
+            _ => panic!(),
+        }
+    };
+    let data_false = json!({
+        "type": "object",
+        "additionalProperties": {"type": "integer"}
+    });
+    if let Ok(schema) = serde_json::from_value::<Tag>(data_false) {
+        match schema.object.additional_properties {
+            Some(AdditionalProperties::Object(object)) => {
+                assert_eq!(object.data_type, json!("integer"))
+            }
+            _ => panic!(),
+        }
+    };
+}
+
+#[test]
+fn test_deserialize_type_object_additional_properties() {
+    let data = json!({
+        "type": "object",
+        "properties": {
+            "test-int": {"type": "integer"},
+            "test-null": {"type": "null"}
+        }
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    let props = schema.object.properties.unwrap();
+    assert_eq!(props.len(), 2);
+    let test_int = props.get("test-int").unwrap();
+    assert_eq!(test_int.data_type, json!("integer"));
+}
+
+#[test]
+fn test_deserialize_type_nested_object() {
+    let data = json!({
+        "type": "object",
+        "properties": {
+            "nested-object": {
+                "type": "object",
+                "properties": {
+                    "test-int": {"type": "int"}
+                }
+            },
+        }
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    let props = schema.object.properties.as_ref().unwrap();
+    assert_eq!(props.len(), 1);
+    let nested_object = *props.get("nested-object").as_ref().unwrap();
+    assert_eq!(nested_object.data_type, json!("object"));
+    let nested_object_props = nested_object.object.properties.as_ref().unwrap();
+    assert_eq!(nested_object_props.len(), 1);
 }
 
 #[test]
 fn test_deserialize_type_array() {
-    panic!()
+    let data = json!({
+        "type": "array",
+        "items": {
+            "type": "integer"
+        }
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    let items = schema.array.items.unwrap();
+    assert_eq!(items.data_type, json!("integer"))
 }
 
 #[test]
 fn test_deserialize_type_one_of() {
-    panic!()
+    let data = json!({
+        "oneOf": [
+            {"type": "integer"},
+            {"type": "null"}
+        ],
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    assert!(schema.data_type.is_null());
+    let one_of = schema.one_of.unwrap();
+    assert_eq!(one_of.len(), 2);
+    assert_eq!(one_of[0].data_type, json!("integer"));
+    assert_eq!(one_of[1].data_type, json!("null"));
 }
 
 #[test]
 fn test_deserialize_type_all_of() {
-    panic!()
+    let data = json!({
+        "allOf": [
+            {"type": "integer"},
+            {"type": "null"}
+        ],
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    assert!(schema.data_type.is_null());
+    let all_of = schema.all_of.unwrap();
+    assert_eq!(all_of.len(), 2);
+    assert_eq!(all_of[0].data_type, json!("integer"));
+    assert_eq!(all_of[1].data_type, json!("null"));
 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -101,6 +101,22 @@ fn test_deserialize_type_null() {
 
 #[test]
 fn test_deserialize_type_object() {
+    let data = json!({
+        "type": "object",
+        "properties": {
+            "test-int": {"type": "integer"},
+            "test-null": {"type": "null"}
+        }
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    let props = schema.object.properties.unwrap();
+    assert_eq!(props.len(), 2);
+    let test_int = props.get("test-int").unwrap();
+    assert_eq!(test_int.data_type, json!("integer"));
+}
+
+#[test]
+fn test_deserialize_type_object_additional_properties() {
     let data_true = json!({
         "type": "object",
         "additionalProperties": true
@@ -133,22 +149,6 @@ fn test_deserialize_type_object() {
             _ => panic!(),
         }
     };
-}
-
-#[test]
-fn test_deserialize_type_object_additional_properties() {
-    let data = json!({
-        "type": "object",
-        "properties": {
-            "test-int": {"type": "integer"},
-            "test-null": {"type": "null"}
-        }
-    });
-    let schema: Tag = serde_json::from_value(data).unwrap();
-    let props = schema.object.properties.unwrap();
-    assert_eq!(props.len(), 2);
-    let test_int = props.get("test-int").unwrap();
-    assert_eq!(test_int.data_type, json!("integer"));
 }
 
 #[test]

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase", tag = "type")]
+enum Type {
+    Null,
+    Boolean,
+    Number,
+    Integer,
+    String,
+    Object(Object),
+    Array(Array),
+    OneOf(OneOf),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum AdditionalProperties {
+    Boolean,
+    Object(Tag),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Object {
+    properties: Option<HashMap<String, Box<Tag>>>,
+    additionalProperties: Option<AdditionalProperties>,
+    patternProperties: Option<Box<Tag>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Array {
+    items: Vec<Tag>,
+}
+
+// Needs a custom deserializer
+#[derive(Serialize, Deserialize, Debug)]
+struct OneOf {
+    oneof: Vec<Tag>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+struct Tag {
+    #[serde(flatten, rename = "type")]
+    data_type: Box<Type>,
+}

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -1,3 +1,5 @@
+/// A JSON Schema serde module derived from the v4 spec.
+/// Refer to http://json-schema.org/draft-04/schema for spec details.
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -1,45 +1,121 @@
+use serde::de::{self, Deserialize, Deserializer};
+use serde::ser::{self, Serialize, Serializer};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "lowercase", tag = "type")]
-enum Type {
+#[serde(rename_all = "lowercase")]
+enum SimpleType {
     Null,
     Boolean,
     Number,
     Integer,
     String,
-    Object(Object),
-    Array(Array),
-    OneOf(OneOf),
+    Object,
+    Array,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 enum AdditionalProperties {
-    Boolean,
-    Object(Tag),
+    True,
+    False,
+    Object(Box<Tag>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Object {
     properties: Option<HashMap<String, Box<Tag>>>,
-    additionalProperties: Option<AdditionalProperties>,
-    patternProperties: Option<Box<Tag>>,
+    #[serde(flatten, rename = "camelCase")]
+    additional_properties: Option<AdditionalProperties>,
+    #[serde(flatten, rename = "camelCase")]
+    pattern_properties: Option<Box<Tag>>,
 }
+
+/// Represent an array of subschemas
+type TagArray = Vec<Box<Tag>>;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Array {
-    items: Vec<Tag>,
+    items: TagArray,
 }
 
-// Needs a custom deserializer
-#[derive(Serialize, Deserialize, Debug)]
-struct OneOf {
-    oneof: Vec<Tag>,
+type OneOf = TagArray;
+type AllOf = TagArray;
+
+#[derive(Debug)]
+enum Type {
+    Simple(SimpleType),
+    Multi(Vec<SimpleType>),
+}
+
+impl Serialize for Type {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Type::Simple(atom) => SimpleType::serialize(atom, serializer),
+            Type::Multi(list) => Vec::<SimpleType>::serialize(list, serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Type {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = Value::deserialize(deserializer)?;
+        if let Ok(atom) = SimpleType::deserialize(&v) {
+            return Ok(Type::Simple(atom));
+        } else if let Ok(list) = Vec::<SimpleType>::deserialize(&v) {
+            return Ok(Type::Multi(list));
+        } else {
+            return Err(de::Error::custom("Error deserializing type!"));
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 struct Tag {
     #[serde(flatten, rename = "type")]
-    data_type: Box<Type>,
+    data_type: Type,
+    #[serde(flatten)]
+    object: Option<Object>,
+    #[serde(flatten)]
+    extra: Option<HashMap<String, Value>>,
+    #[serde(flatten, rename = "camelCase")]
+    one_of: Option<OneOf>,
+    #[serde(flatten, rename = "camelCase")]
+    all_of: Option<AllOf>,
+}
+
+use serde_json::json;
+
+#[test]
+fn test_serialize_type_null() {
+    let schema = Tag {
+        data_type: Type::Simple(SimpleType::Null),
+        object: None,
+        extra: None,
+        one_of: None,
+        all_of: None,
+    };
+    let expect = json!({
+        "type": "null"
+    });
+    assert_eq!(expect, json!(schema))
+}
+
+#[test]
+fn test_deserialize_type_null() {
+    let data = json!({
+        "type": "null"
+    });
+    let schema: Tag = serde_json::from_value(data).unwrap();
+    match schema.data_type {
+        Type::Simple(SimpleType::Null) => (),
+        _ => panic!(),
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate serde_json;
 
 mod ast;
 mod bigquery;
+mod jsonschema;
 
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet, VecDeque};


### PR DESCRIPTION
This adds serde for JSONSchema that can be used to transform into and out of the ast module.

I referenced the JSON Schema v4 meta-schema when building up the grammar: http://json-schema.org/draft-04/schema. It provides a useful skeleton for how to create the data structure.

There are some interesting bits to serde attributes that were also pain points -- I'll point them out in a self-review.
