### PR TITLE
Collapse Type::Union into a flattened type

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
 use std::collections::HashMap;
+use super::jsonschema;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
@@ -65,6 +66,10 @@ impl Union {
             items: items.into_iter().map(Box::new).collect(),
         }
     }
+
+    fn collapse(&self) -> Tag {
+        unimplemented!()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -103,6 +108,20 @@ impl Tag {
             name: name,
             nullable: nullable,
         }
+    }
+
+    fn infer_name(&mut self) {
+        unimplemented!()
+    }
+
+    fn infer_nullability(&mut self) {
+        unimplemented!()
+    }
+}
+
+impl From<jsonschema::Tag> for Tag {
+    fn from(tag: jsonschema::Tag) -> Self {
+        tag.type_into_ast()
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -174,189 +174,6 @@ impl Union {
     }
 }
 
-#[test]
-fn test_union_collapse_atom() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": {"atom": "integer"}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "atom": "integer",
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_atom_repeats() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": {"atom": "integer"}},
-            {"type": {"atom": "integer"}},
-            {"type": {"atom": "integer"}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "atom": "integer",
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_nullable_atom() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": "null"},
-            {"type": {"atom": "integer"}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "atom": "integer",
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_type_conflict() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": {"atom": "string"}},
-            {"type": {"atom": "integer"}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "atom": "json",
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_object_merge() {
-    let data = json!({
-    "union": {
-        "items": [
-            {
-                "type": {
-                    "object": {
-                        "fields": {
-                            "atom_0": {"type": {"atom": "boolean"}},
-                            "atom_1": {"type": {"atom": "integer"}},
-                        }}}},
-            {
-                "type": {
-                    "object": {
-                        "fields": {
-                            "atom_1": {"type": {"atom": "integer"}},
-                            "atom_2": {"type": {"atom": "string"}},
-                        }}}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-    "object": {
-        "fields": {
-            "atom_0": {"type": {"atom": "boolean"}, "nullable": false},
-            "atom_1": {"type": {"atom": "integer"}, "nullable": false},
-            "atom_2": {"type": {"atom": "string"}, "nullable": false},
-        }}});
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_object_conflict() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": {"atom": "string"}},
-            {"type": {"atom": "integer"}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "atom": "json",
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_array_nullable_atom() {
-    let data = json!({
-    "union": {
-        "items": [
-            {"type": {"array": {"items": {"type": {"atom": "integer"}}}}},
-            {"type": {"array": {"items": {"type": "null"}}}},
-        ]}});
-    let dtype: Type = serde_json::from_value(data).unwrap();
-    let expect = json!({
-        "array": {"items": {"type": {"atom": "integer"}, "nullable": true}}
-    });
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
-#[test]
-fn test_union_collapse_map_nullable_atom() {
-    let dtype = Type::Union(Union::new(vec![
-        Tag::new(
-            Type::Map(Map::new(
-                None,
-                Tag::new(Type::Atom(Atom::Integer), None, false),
-            )),
-            None,
-            false,
-        ),
-        Tag::new(
-            Type::Map(Map::new(None, Tag::new(Type::Null, None, false))),
-            None,
-            false,
-        ),
-    ]));
-    let expect = json!({
-    "map": {
-        "key": {
-            "type": {"atom": "string"},
-            "nullable": false,
-        },
-        "value": {
-            "type": {"atom": "integer"},
-            "nullable": true,
-        }}});
-    if let Type::Union(union) = dtype {
-        assert_eq!(expect, json!(union.collapse().data_type))
-    } else {
-        panic!()
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
@@ -628,4 +445,187 @@ fn test_serialize_union() {
         "nullable": false
     });
     assert_eq!(expect, json!(union))
+}
+
+#[test]
+fn test_union_collapse_atom() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": {"atom": "integer"}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "atom": "integer",
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_atom_repeats() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": {"atom": "integer"}},
+            {"type": {"atom": "integer"}},
+            {"type": {"atom": "integer"}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "atom": "integer",
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_nullable_atom() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": "null"},
+            {"type": {"atom": "integer"}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "atom": "integer",
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_type_conflict() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": {"atom": "string"}},
+            {"type": {"atom": "integer"}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "atom": "json",
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_object_merge() {
+    let data = json!({
+    "union": {
+        "items": [
+            {
+                "type": {
+                    "object": {
+                        "fields": {
+                            "atom_0": {"type": {"atom": "boolean"}},
+                            "atom_1": {"type": {"atom": "integer"}},
+                        }}}},
+            {
+                "type": {
+                    "object": {
+                        "fields": {
+                            "atom_1": {"type": {"atom": "integer"}},
+                            "atom_2": {"type": {"atom": "string"}},
+                        }}}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+    "object": {
+        "fields": {
+            "atom_0": {"type": {"atom": "boolean"}, "nullable": false},
+            "atom_1": {"type": {"atom": "integer"}, "nullable": false},
+            "atom_2": {"type": {"atom": "string"}, "nullable": false},
+        }}});
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_object_conflict() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": {"atom": "string"}},
+            {"type": {"atom": "integer"}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "atom": "json",
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_array_nullable_atom() {
+    let data = json!({
+    "union": {
+        "items": [
+            {"type": {"array": {"items": {"type": {"atom": "integer"}}}}},
+            {"type": {"array": {"items": {"type": "null"}}}},
+        ]}});
+    let dtype: Type = serde_json::from_value(data).unwrap();
+    let expect = json!({
+        "array": {"items": {"type": {"atom": "integer"}, "nullable": true}}
+    });
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn test_union_collapse_map_nullable_atom() {
+    let dtype = Type::Union(Union::new(vec![
+        Tag::new(
+            Type::Map(Map::new(
+                None,
+                Tag::new(Type::Atom(Atom::Integer), None, false),
+            )),
+            None,
+            false,
+        ),
+        Tag::new(
+            Type::Map(Map::new(None, Tag::new(Type::Null, None, false))),
+            None,
+            false,
+        ),
+    ]));
+    let expect = json!({
+    "map": {
+        "key": {
+            "type": {"atom": "string"},
+            "nullable": false,
+        },
+        "value": {
+            "type": {"atom": "integer"},
+            "nullable": true,
+        }}});
+    if let Type::Union(union) = dtype {
+        assert_eq!(expect, json!(union.collapse().data_type))
+    } else {
+        panic!()
+    }
 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -115,9 +115,9 @@ impl Tag {
             Atom::String => ast::Tag::new(ast::Type::Atom(ast::Atom::String), None, false),
             Atom::Object => match &self.object.properties {
                 Some(properties) => {
-                    let mut fields: HashMap<String, Box<ast::Tag>> = HashMap::new();
+                    let mut fields: HashMap<String, ast::Tag> = HashMap::new();
                     for (key, value) in properties {
-                        fields.insert(key.to_string(), Box::new(value.type_into_ast()));
+                        fields.insert(key.to_string(), value.type_into_ast());
                     }
                     ast::Tag::new(ast::Type::Object(ast::Object::new(fields)), None, false)
                 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -60,7 +60,7 @@ struct Array {
 /// Container for the main body of the schema.
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase", tag = "type")]
-struct Tag {
+pub struct Tag {
     #[serde(rename = "type", default)]
     data_type: Value,
     #[serde(flatten)]
@@ -174,12 +174,6 @@ impl Tag {
                 }
             },
         }
-    }
-}
-
-impl Into<ast::Tag> for Tag {
-    fn into(self) -> ast::Tag {
-        self.type_into_ast()
     }
 }
 

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -168,11 +168,15 @@ impl Tag {
             },
             Atom::Array => {
                 if let Some(items) = &self.array.items {
-                    ast::Tag::new(ast::Type::Array(ast::Array::new(items.type_into_ast())), None, false)
+                    ast::Tag::new(
+                        ast::Type::Array(ast::Array::new(items.type_into_ast())),
+                        None,
+                        false,
+                    )
                 } else {
                     panic!("array missing item")
                 }
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes #19.

This PR adds a few things to the ast module:

* Derive `Clone` for most of the structs
* Implements a `Union::collapse` method which flattens union types
* Implements a `Tag::infer_name` method for adding missing names to objects
* Moves `Into<ast::Tag> for jsonschema::Tag` to `From<jsonschema::Tag> for ast::Tag`, which gives `into` for free. 