### PR TITLE
Implement `From<ast::Tag> for bigquery::Tag` 

### DIFF
--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -83,10 +83,60 @@ pub struct Tag {
     mode: Mode,
 }
 
+impl From<ast::Tag> for Tag {
+    fn from(tag: ast::Tag) -> Tag {
+        let mut tag = match tag.data_type {
+            ast::Type::Union(union) => union.collapse(),
+            _ => tag,
+        };
+        tag.infer_name();
+        let data_type = match &tag.data_type {
+            ast::Type::Atom(atom) => Type::Atom(match atom {
+                ast::Atom::Boolean => Atom::Bool,
+                ast::Atom::Integer => Atom::Int64,
+                ast::Atom::Number => Atom::Float64,
+                ast::Atom::String => Atom::String,
+                ast::Atom::JSON => Atom::String,
+            }),
+            ast::Type::Object(object) => {
+                let fields: HashMap<String, Box<Tag>> = object
+                    .fields
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), Box::new(Tag::from(*v.clone()))))
+                    .collect();
+                Type::Record(Record { fields: fields })
+            }
+            ast::Type::Array(array) => *Tag::from(*array.items.clone()).data_type,
+            ast::Type::Map(map) => {
+                let key = Tag::from(*map.key.clone());
+                let value = Tag::from(*map.value.clone());
+                let fields: HashMap<String, Box<Tag>> = vec![("key", key), ("value", value)]
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), Box::new(v)))
+                    .collect();
+                Type::Record(Record { fields: fields })
+            }
+            _ => Type::Atom(Atom::String),
+        };
+        let mode = if tag.is_array() || tag.is_map() {
+            Mode::Repeated
+        } else if tag.is_null() || tag.nullable {
+            Mode::Nullable
+        } else {
+            Mode::Required
+        };
+        Tag {
+            name: tag.name.clone(),
+            data_type: Box::new(data_type),
+            mode: mode,
+        }
+    }
+}
+
 // See: https://serde.rs/custom-date-format.html#date-in-a-custom-format
 mod fields_as_vec {
-    use super::{Record, Tag};
-    use serde::ser::{self, SerializeSeq, Serializer};
+    use super::Tag;
+    use serde::ser::{SerializeSeq, Serializer};
     use serde::{Deserialize, Deserializer};
     use std::collections::HashMap;
     use std::iter::FromIterator;
@@ -96,7 +146,13 @@ mod fields_as_vec {
         S: Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(map.len()))?;
-        for (_, element) in map {
+        let mut vec: Vec<(String, &Tag)> = map
+            .iter()
+            .map(|(k, v)| (k.to_string(), &**v))
+            .collect();
+        vec.sort_by_key(|(k, _)| k.to_string());
+
+        for (_, element) in vec {
             seq.serialize_element(element)?;
         }
         seq.end()
@@ -118,7 +174,7 @@ mod fields_as_vec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde_json::{self, json};
 
     #[test]
     fn test_serialize_atom() {
@@ -293,5 +349,132 @@ mod tests {
             Type::Atom(Atom::Int64) => (),
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn test_from_ast_null() {
+        let data = json!({
+            "type": "null"
+        });
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "STRING",
+            "mode": "NULLABLE",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_atom() {
+        let data = json!({
+            "type": {"atom": "integer"}
+        });
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "INT64",
+            "mode": "REQUIRED",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_nullable_atom() {
+        let data = json!({
+            "type": {"atom": "integer"},
+            "nullable": true,
+        });
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "INT64",
+            "mode": "NULLABLE",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_union_nullable_atom() {
+        let data = json!({
+        "type": {
+            "union": {
+                "items": [
+                    {"type": "null"},
+                    {"type": {"atom": "integer"}},
+        ]}}});
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "INT64",
+            "mode": "NULLABLE",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_object() {
+        let data = json!({
+        "type": {
+            "object": {
+                "fields": {
+                    "test-null": {"type": "null"},
+                    "test-atom": {"type": {"atom": "integer"}},
+                    "test-object": {"type": {
+                        "object": {
+                            "fields": {
+                                "test-nested-atom": {"type": {"atom": "number"}}
+                            }}}}}}}});
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "RECORD",
+            "mode": "REQUIRED",
+            "fields": [
+                {"name": "test-atom", "type": "INT64", "mode": "REQUIRED"},
+                {"name": "test-null", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "test-object", "type": "RECORD", "mode": "REQUIRED", "fields": [
+                    {"name": "test-nested-atom", "type": "FLOAT64", "mode": "REQUIRED"},
+                ]},
+            ]
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_array() {
+        let data = json!({
+        "type": {
+            "array": {
+                "items": {
+                    "type": {"atom": "integer"}},
+        }}});
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+            "type": "INT64",
+            "mode": "REPEATED",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
+    fn test_from_ast_map() {
+        let data = json!({
+        "type": {
+            "map": {
+                "key": {"type": {"atom": "string"}},
+                "value": {"type": {"atom": "integer"}}
+        }}});
+        let jschema: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = jschema.into();
+        let expect = json!({
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+            {"name": "key", "type": "STRING", "mode": "REQUIRED"},
+            {"name": "value", "type": "INT64", "mode": "REQUIRED"},
+        ]});
+        assert_eq!(expect, json!(bq));
     }
 }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -430,15 +430,18 @@ mod tests {
             "object": {
                 "fields": {
                     "test-int": {
+                        "name": "test-int",
                         "type": {"atom": "integer"},
                         "nullable": false,
                     },
                     "test-obj": {
+                        "name": "test-obj",
                         "nullable": false,
                         "type": {
                             "object": {
                                 "fields": {
                                     "test-null": {
+                                        "name": "test-null",
                                         "type": "null",
                                         "nullable": false,
                                     }}}}}}}}});
@@ -463,15 +466,18 @@ mod tests {
         "type": {
             "map": {
                 "key": {
+                    "name": "key",
                     "nullable": false,
                     "type": {"atom": "string"}
                 },
                 "value": {
+                    "name": "value",
                     "nullable": false,
                     "type": {
                         "object": {
                             "fields": {
                                 "test-int": {
+                                    "name": "test-int",
                                     "nullable": false,
                                     "type": {"atom": "integer"}
                                 }}}}}}}});


### PR DESCRIPTION
This fixes #13. 

* Adds public visibility for ast structs
* Adds implementation of `From<ast::Tag> for bigquery::Tag`
* Adds tests