### PR TITLE
Specify version numbers in cargo manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -93,6 +92,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,10 @@ edition = "2018"
 name = "jst"
 
 [dependencies]
-clap = "*"
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
+clap = "~2.32"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [build-dependencies]
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 #[macro_use]
-extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #[macro_use]
-extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 


### PR DESCRIPTION
This pins dependencies to known versions. 