### PR TITLE
Implement grammar for Avro

### DIFF
--- a/src/avro.rs
+++ b/src/avro.rs
@@ -87,34 +87,89 @@ mod tests {
     fn serialize_primitive() {
         unimplemented!()
     }
-    #[test]
-    fn serialize_complex_record() {        unimplemented!()
-}
-    fn serialize_complex_enum() {        unimplemented!()
-}
-    fn serialize_complex_array() {        unimplemented!()
-}
-    fn serialize_complex_map() {        unimplemented!()
-}
-    fn serialize_complex_fixed() {        unimplemented!()
-}
-    fn deserialize_primitive() {        unimplemented!()
-}
-    fn deserialize_complex_record() {        unimplemented!()
-}
-    fn deserialize_complex_enum() {        unimplemented!()
-}
-    fn deserialize_complex_array() {        unimplemented!()
-}
-    fn deserialize_complex_map() {        unimplemented!()
-}
-    fn deserialize_complex_fixed() {        unimplemented!()
-}
 
-    fn from_ast_null() {}
-    fn from_ast_atom() {}
-    fn from_ast_object() {}
-    fn from_ast_map() {}
-    fn from_ast_array() {}
-    fn from_ast_union() {}
+    #[test]
+    fn serialize_complex_record() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn serialize_complex_enum() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn serialize_complex_array() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn serialize_complex_map() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn serialize_complex_fixed() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_primitive() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_record() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_enum() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_array() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_map() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_fixed() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_null() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_atom() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_object() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_map() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_array() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn from_ast_union() {
+        unimplemented!()
+    }
 }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -141,21 +141,56 @@ mod tests {
             ]
         });
 
-        assert_serialize(expect, schema)
+        assert_serialize(expect, schema);
     }
 
     #[test]
     fn serialize_complex_enum() {
-        unimplemented!()
+        let schema = Type::Complex(Complex::Enum(Enum {
+            common: CommonAttributes {
+                name: "test-enum".into(),
+                ..Default::default()
+            },
+            symbols: vec!["A".into(), "B".into(), "C".into()],
+        }));
+        let expect = json!({
+            "type": "enum",
+            "name": "test-enum",
+            "symbols": ["A", "B", "C"]
+        });
+        assert_serialize(expect, schema);
     }
 
     #[test]
     fn serialize_complex_array() {
-        unimplemented!()
+        let schema = Type::Complex(Complex::Array(Array {
+            items: Box::new(Type::Primitive(Primitive::String)),
+        }));
+        let expect = json!({
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        });
+        assert_serialize(expect, schema);
     }
 
     #[test]
     fn serialize_complex_map() {
+        let schema = Type::Complex(Complex::Map(Map {
+            values: Box::new(Type::Primitive(Primitive::Long)),
+        }));
+        let expect = json!({
+            "type": "map",
+            "values": {
+                "type": "long"
+            }
+        });
+        assert_serialize(expect, schema);
+    }
+
+    #[test]
+    fn serialize_complex_union() {
         unimplemented!()
     }
 
@@ -186,6 +221,11 @@ mod tests {
 
     #[test]
     fn deserialize_complex_map() {
+        unimplemented!()
+    }
+
+    #[test]
+    fn deserialize_complex_union() {
         unimplemented!()
     }
 

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -1,0 +1,120 @@
+/// https://avro.apache.org/docs/current/spec.html
+use super::ast;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Primitive {
+    Null,
+    Boolean,
+    Int,
+    Long,
+    Float,
+    Double,
+    Bytes,
+    String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct CommonAttributes {
+    name: String,
+    namespace: Option<String>,
+    doc: Option<String>,
+    aliases: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Record {
+    #[serde(flatten)]
+    common: CommonAttributes,
+    fields: HashMap<String, Field>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Field {
+    name: String,
+    doc: Option<String>,
+    data_type: Type,
+    default: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Enum {
+    #[serde(flatten)]
+    common: CommonAttributes,
+    symbols: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Array {
+    items: Box<Type>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Map {
+    values: Box<Type>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Fixed {
+    // this field, however, does not support the doc attribute
+    #[serde(flatten)]
+    common: CommonAttributes,
+    size: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Complex {
+    Record(Record),
+    Enum(Enum),
+    Array(Array),
+    Map(Map),
+    Fixed(Fixed),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Type {
+    Primitive(Primitive),
+    Complex(Complex),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn serialize_primitive() {
+        unimplemented!()
+    }
+    #[test]
+    fn serialize_complex_record() {        unimplemented!()
+}
+    fn serialize_complex_enum() {        unimplemented!()
+}
+    fn serialize_complex_array() {        unimplemented!()
+}
+    fn serialize_complex_map() {        unimplemented!()
+}
+    fn serialize_complex_fixed() {        unimplemented!()
+}
+    fn deserialize_primitive() {        unimplemented!()
+}
+    fn deserialize_complex_record() {        unimplemented!()
+}
+    fn deserialize_complex_enum() {        unimplemented!()
+}
+    fn deserialize_complex_array() {        unimplemented!()
+}
+    fn deserialize_complex_map() {        unimplemented!()
+}
+    fn deserialize_complex_fixed() {        unimplemented!()
+}
+
+    fn from_ast_null() {}
+    fn from_ast_atom() {}
+    fn from_ast_object() {}
+    fn from_ast_map() {}
+    fn from_ast_array() {}
+    fn from_ast_union() {}
+}

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -196,7 +196,19 @@ mod tests {
 
     #[test]
     fn serialize_complex_fixed() {
-        unimplemented!()
+        let schema = Type::Complex(Complex::Fixed(Fixed {
+            common: CommonAttributes {
+                name: "md5".into(),
+                ..Default::default()
+            },
+            size: 16,
+        }));
+        let expect = json!({
+            "type": "fixed",
+            "size": 16,
+            "name": "md5"
+        });
+        assert_serialize(expect, schema);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate serde;
 extern crate serde_json;
 
 mod ast;
+mod avro;
 mod bigquery;
 mod jsonschema;
 


### PR DESCRIPTION
This fixes #14. I learned from the other grammars, making the avro schema cleaner than the other implementations. The spec was useful during this stage.

https://avro.apache.org/docs/current/spec.html

* Unions are implemented using standard serde attributes. In the `jsonschema` module, I left the type as a `Value` and implemented a helper function to disambiguate `Type` from a `Vec<Type>`.

https://github.com/acmiyaguchi/jsonschema-transpiler/blob/2de4ca494d8488fac1d4041ddcf88d189bbf3671/src/jsonschema.rs#L79-L85

* I also avoided the issue with flattening a nested enum by treating the enum as an untagged union. I ran into issues treating the main `Type` as a tagged-union and adding the `serde(tag = "type")` attribute on all involved types. This will flatten to the correct json format, but it requires custom deserialization. In the `bigquery` module, I had to implement a custom deserializer.

https://github.com/acmiyaguchi/jsonschema-transpiler/blob/2de4ca494d8488fac1d4041ddcf88d189bbf3671/src/bigquery.rs#L52-L55

* I avoided using HashMaps for things that are actually Vecs. In `bigquery`, I did this because it makes traversal and insertions into the schema simpler. However, most of the manipulation is done within `ast` now, so having an easily traversable schema by path is no longer of concern.

https://github.com/acmiyaguchi/jsonschema-transpiler/blob/2de4ca494d8488fac1d4041ddcf88d189bbf3671/src/bigquery.rs#L69-L72