### PR TITLE
Fix namespace generation in Avro schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +61,7 @@ name = "jsonschema_transpiler"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -55,6 +70,25 @@ dependencies = [
 name = "libc"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -190,8 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+"checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "d3797b7142c9aa74954e351fc089bbee7958cebbff6bf2815e7ffff0b19f547d"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = "1.0"
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+pretty_assertions = "0.6.1"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -40,6 +40,19 @@ impl Array {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Tuple {
+    pub items: Vec<Tag>,
+}
+
+impl Tuple {
+    pub fn new(items: Vec<Tag>) -> Self {
+        Tuple {
+            items: items.clone(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Map {
     pub key: Box<Tag>,
     pub value: Box<Tag>,
@@ -211,6 +224,7 @@ pub enum Type {
     Object(Object),
     Map(Map),
     Array(Array),
+    Tuple(Tuple),
     Union(Union),
     // Intersection
     // Not

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,6 +66,7 @@ impl Map {
                 namespace: None,
                 data_type: Type::Atom(Atom::String),
                 nullable: false,
+                is_root: false,
             }),
             value: Box::new(value),
         }
@@ -101,6 +102,7 @@ impl Union {
                 name: None,
                 namespace: None,
                 nullable: is_null,
+                is_root: false,
                 data_type: self.items[0].data_type.clone(),
             };
         }
@@ -213,6 +215,7 @@ impl Union {
             namespace: None,
             nullable,
             data_type,
+            is_root: false,
         };
         tag.infer_nullability();
         tag
@@ -253,6 +256,9 @@ pub struct Tag {
 
     #[serde(default)]
     pub nullable: bool,
+
+    #[serde(default, skip_serializing)]
+    pub is_root: bool,
 }
 
 impl Tag {
@@ -262,6 +268,7 @@ impl Tag {
             name,
             namespace: None,
             nullable,
+            is_root: false,
         }
     }
 
@@ -380,6 +387,7 @@ impl From<jsonschema::Tag> for Tag {
         let mut tag = tag.type_into_ast();
         tag.infer_name();
         tag.infer_nullability();
+        tag.is_root = true;
         tag
     }
 }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -105,18 +105,12 @@ impl Default for Type {
 
 impl From<ast::Tag> for Type {
     fn from(tag: ast::Tag) -> Self {
-        let mut tag = match tag.data_type {
-            ast::Type::Union(union) => {
-                let mut collapsed = union.collapse();
-                collapsed.name = tag.name.clone();
-                collapsed
-            }
-            _ => tag,
-        };
+        let mut tag = tag;
         if tag.is_root {
             // Name inference is run only from the root for the proper
             // construction of the namespace. Fully qualified names require a
             // top-down approach.
+            tag.collapse();
             tag.name = Some("root".into());
             tag.infer_name();
         }
@@ -546,6 +540,8 @@ mod tests {
     /// The union type is collapsed before being reconstructed
     fn from_ast_union() {
         let ast = json!({
+            // test this document as if it were root
+            "is_root": true,
             "type": {"union": {"items": [
                 {"type": "null"},
                 {"type": {"atom": "boolean"}},

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -168,6 +168,7 @@ impl From<ast::Tag> for Type {
 mod tests {
     use super::*;
     use serde_json::json;
+    use pretty_assertions::assert_eq;
 
     fn assert_serialize(expect: Value, schema: Type) {
         assert_eq!(expect, json!(schema))

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -291,12 +291,10 @@ mod tests {
                 Type::Primitive(Primitive::Long),
             ],
         });
-        let expect = json!({
-            "type": [
-                {"type": "null"},
-                {"type": "long"},
-            ]
-        });
+        let expect = json!([
+            {"type": "null"},
+            {"type": "long"},
+        ]);
         assert_serialize(expect, schema);
     }
 
@@ -400,12 +398,10 @@ mod tests {
 
     #[test]
     fn deserialize_complex_union() {
-        let data = json!({
-            "type": [
-                {"type": "null"},
-                {"type": "long"},
-            ]
-        });
+        let data = json!([
+            {"type": "null"},
+            {"type": "long"},
+        ]);
         match type_from_value(data) {
             Type::Union(union) => {
                 match union.data_type[0] {
@@ -458,16 +454,17 @@ mod tests {
                 // An additional case could be made for the behavior of nested
                 // structs and nested arrays. A nullable array for example may
                 // not be a valid structure in bigquery.
-                "required": ["1-test-int", "2-test-nested", "3-test-array"],
+                "required": ["1-test-int", "3-test-nested", "4-test-array"],
                 "fields": {
                     "0-test-null": {"type": "null"},
                     "1-test-int": {"type": {"atom": "integer"}},
-                    "2-test-nested": {"type": {"object": {"fields": {
+                    "2-test-null-int": {"type": {"atom": "integer"}, "nullable": true},
+                    "3-test-nested": {"type": {"object": {"fields": {
                         "test-bool": {
                             "type": {"atom": "boolean"},
                             "nullable": true
                             }}}}},
-                    "3-test-array": {"type": {"array": {
+                    "4-test-array": {"type": {"array": {
                         "items": {"type": {"atom": "integer"}}}}},
             }}}
         });
@@ -477,17 +474,20 @@ mod tests {
             "fields": [
                 {"name": "0-test-null", "type": {"type": "null"}},
                 {"name": "1-test-int", "type": {"type": "int"}},
-                {"name": "2-test-nested", "type": {
-                    "name": "2-test-nested",
+                {"name": "2-test-null-int", "type": [
+                    {"type": "null"},
+                    {"type": "int"},
+                ]},
+                {"name": "3-test-nested", "type": {
+                    "name": "3-test-nested",
                     "type": "record",
                     "fields": [
-                        {"name": "test-bool", "type": {
-                            "type": [
+                        {"name": "test-bool", "type": [
                                 {"type": "null"},
                                 {"type": "boolean"},
-                            ]}},
+                            ]},
                     ]}},
-                {"name": "3-test-array", "type": {
+                {"name": "4-test-array", "type": {
                     "type": "array",
                     "items": {"type": "int"}
                 }}
@@ -532,12 +532,10 @@ mod tests {
                 {"type": {"atom": "boolean"}},
             ]}}
         });
-        let avro = json!({
-            "type": [
-                {"type": "null"},
-                {"type": "boolean"}
-            ]
-        });
+        let avro = json!([
+            {"type": "null"},
+            {"type": "boolean"}
+        ]);
         assert_from_ast_eq(ast, avro);
     }
 }

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -140,6 +140,7 @@ impl From<ast::Tag> for Type {
                     common: CommonAttributes {
                         // This is not a safe assumption
                         name: tag.name.clone().unwrap_or("root".into()),
+                        namespace: tag.namespace.clone(),
                         ..Default::default()
                     },
                     fields,

--- a/src/avro.rs
+++ b/src/avro.rs
@@ -68,7 +68,6 @@ pub struct Map {
     values: Box<Type>,
 }
 
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Fixed {
     // this field, however, does not support the doc attribute
@@ -511,6 +510,23 @@ mod tests {
             "type": "array",
             "items": {"type": "string"}
         });
+        assert_from_ast_eq(ast, avro);
+    }
+
+    #[test]
+    fn from_ast_tuple() {
+        // This case is not handled and instead converted into an object
+        let ast = json!({
+            "type": {
+                "tuple": {
+                    "items": [
+                        {"type": {"atom": "boolean"}},
+                        {"type": {"atom": "integer"}},
+                    ]
+                }
+            }
+        });
+        let avro = json!({"type": "string"});
         assert_from_ast_eq(ast, avro);
     }
 

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -85,14 +85,8 @@ pub struct Tag {
 
 impl From<ast::Tag> for Tag {
     fn from(tag: ast::Tag) -> Tag {
-        let mut tag = match tag.data_type {
-            ast::Type::Union(union) => {
-                let mut collapsed = union.collapse();
-                collapsed.name = tag.name.clone();
-                collapsed
-            }
-            _ => tag,
-        };
+        let mut tag = tag;
+        tag.collapse();
         tag.infer_name();
         tag.infer_nullability();
         let data_type = match &tag.data_type {

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -463,6 +463,27 @@ mod tests {
     }
 
     #[test]
+    fn test_from_ast_tuple() {
+        let data = json!({
+            "type": {
+                "tuple": {
+                    "items": [
+                        {"type": {"atom": "boolean"}},
+                        {"type": {"atom": "integer"}},
+                    ]
+                }
+            }
+        });
+        let tag: ast::Tag = serde_json::from_value(data).unwrap();
+        let bq: Tag = tag.into();
+        let expect = json!({
+            "type": "STRING",
+            "mode": "REQUIRED",
+        });
+        assert_eq!(expect, json!(bq));
+    }
+
+    #[test]
     fn test_from_ast_map() {
         let data = json!({
         "type": {

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -565,6 +565,7 @@ mod tests {
         "type": {
             "array": {
                 "items": {
+                    "name": "items",
                     "nullable": false,
                     "type": {"atom": "integer"}
                 }}}});

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -506,6 +506,7 @@ mod tests {
                                 "fields": {
                                     "test-null": {
                                         "name": "test-null",
+                                        "namespace": ".test-obj",
                                         "type": "null",
                                         "nullable": true,
                                     }}}}}}}}});
@@ -542,6 +543,7 @@ mod tests {
                             "fields": {
                                 "test-int": {
                                     "name": "test-int",
+                                    "namespace": ".value",
                                     "nullable": true,
                                     "type": {"atom": "integer"}
                                 }}}}}}}});

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -211,6 +211,7 @@ impl Tag {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_serialize_type_null() {

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -465,8 +465,15 @@ mod tests {
             "type": {
                 "union": {
                     "items": [
-                        {"type": "null", "nullable": true},
-                        {"type": {"atom": "integer"}, "nullable": false},
+                        {
+                            // TODO: refactor this test to avoid implementation details
+                            "name": "__union__",
+                            "type": "null",
+                            "nullable": true},
+                        {
+                            "name": "__union__",
+                            "type": {"atom": "integer"},
+                            "nullable": false},
                     ]
                 }
             },
@@ -589,10 +596,12 @@ mod tests {
             "union": {
                 "items": [
                     {
+                        "name": "__union__",
                         "nullable": false,
                         "type": {"atom": "integer"},
                     },
                     {
+                        "name": "__union__",
                         "nullable": true,
                         "type": "null"
                     }

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -50,11 +50,18 @@ type TagArray = Vec<Box<Tag>>;
 type OneOf = TagArray;
 type AllOf = TagArray;
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum ArrayType {
+    Tag(Box<Tag>),
+    TagTuple(TagArray),
+}
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct Array {
     // Using Option<TagArray> would support tuple validation
     #[serde(skip_serializing_if = "Option::is_none")]
-    items: Option<Box<Tag>>,
+    items: Option<ArrayType>,
 }
 
 /// Container for the main body of the schema.
@@ -182,13 +189,19 @@ impl Tag {
             },
             Atom::Array => {
                 if let Some(items) = &self.array.items {
-                    ast::Tag::new(
-                        ast::Type::Array(ast::Array::new(items.type_into_ast())),
-                        None,
-                        false,
-                    )
+                    let data_type = match items {
+                        ArrayType::Tag(items) => {
+                            ast::Type::Array(ast::Array::new(items.type_into_ast()))
+                        }
+                        ArrayType::TagTuple(items) => {
+                            let items: Vec<ast::Tag> =
+                                items.iter().map(|item| item.type_into_ast()).collect();
+                            ast::Type::Tuple(ast::Tuple::new(items))
+                        }
+                    };
+                    ast::Tag::new(data_type, None, false)
                 } else {
-                    panic!("array missing item")
+                    panic!(format!("array missing item: {:#?}", self))
                 }
             }
         }
@@ -346,8 +359,29 @@ mod tests {
             }
         });
         let schema: Tag = serde_json::from_value(data).unwrap();
-        let items = schema.array.items.unwrap();
-        assert_eq!(items.data_type, json!("integer"))
+        if let ArrayType::Tag(items) = schema.array.items.unwrap() {
+            assert_eq!(items.data_type, json!("integer"))
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_deserialize_type_array_tuple() {
+        let data = json!({
+            "type": "array",
+            "items": [
+                {"type": "integer"},
+                {"type": "boolean"}
+            ]
+        });
+        let schema: Tag = serde_json::from_value(data).unwrap();
+        if let ArrayType::TagTuple(items) = schema.array.items.unwrap() {
+            assert_eq!(items[0].data_type, json!("integer"));
+            assert_eq!(items[1].data_type, json!("boolean"));
+        } else {
+            panic!();
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ mod jsonschema;
 use serde_json::{json, Value};
 
 fn into_ast(input: &Value) -> ast::Tag {
-    let jsonschema: jsonschema::Tag = serde_json::from_value(json!(input)).unwrap();
+    let jsonschema: jsonschema::Tag = match serde_json::from_value(json!(input)) {
+        Ok(tag) => tag,
+        Err(e) => panic!(format!("{:#?}", e)),
+    };
     ast::Tag::from(jsonschema)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "128"]
 #[macro_use]
 extern crate serde;
 extern crate serde_json;


### PR DESCRIPTION
This PR, along with [mps#291](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/291) and [mps#290](https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/290) fixes generation of Avro schemas.

* Fixed the type of record fields. They were originally flattened to look like this:
```json
{
   "type":"record",
   "fields":[
      {
         "name":"foo",
         "type":"record",
         "fields":[
            {
               "name":"bar",
               "type":"null"
            }
         ]
      }
   ]
}
```
They should actually be in the following simplified form:
```json
{
   "type":"record",
   "fields":[
      {
         "name":"foo",
         "type": {
             "name": "foo",
             "type":"record",
             "fields":[
                { 
                   "name":"bar",
                   "type":"null"
                }
             ]
           }
      }
   ]
}
```
However, this forces the more verbose form of simple types due to serialization.

* Fixed union types by using vectors directly e.g. `{"type": ["null", "int"]}` to `["null", "int"]`.
* Support de-serialization of tuple-types in jsonschema, but not conversion. 
* Add support for inferring namespaces in `Tag::infer_name`

After running the `./test-mps-valid-avro.py` script, all of the generated schemas should now be valid avro. 