### PR TITLE
Modify cli name and options; bump version to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "jsonschema_transpiler"
+name = "jsonschema-transpiler"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsonschema-transpiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonschema-transpiler"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Anthony Miyaguchi <amiyaguchi@mozilla.com>"]
 description = "A tool to transpile JSON Schema into schemas for data processing"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "jsonschema_transpiler"
+name = "jsonschema-transpiler"
 version = "0.1.0"
 authors = ["Anthony Miyaguchi <amiyaguchi@mozilla.com>"]
+description = "A tool to transpile JSON Schema into schemas for data processing"
+readme = "README.md"
 edition = "2018"
 
 [lib]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,10 @@ use std::fs::File;
 use std::io::BufReader;
 
 fn main() {
-    let matches = App::new("jst")
-        .version("0.1")
-        .author("Anthony Miyaguchi <amiyaguchi@mozilla.com>")
+    let matches = App::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
         .arg(
             Arg::with_name("from-file")
                 .short("f")
@@ -20,10 +21,11 @@ fn main() {
         )
         .arg(
             Arg::with_name("type")
+                .short("t")
                 .long("type")
                 .takes_value(true)
                 .possible_values(&["avro", "bigquery"])
-                .required(true),
+                .default_value("avro")
         )
         .get_matches();
 
@@ -35,7 +37,7 @@ fn main() {
     let output = match matches.value_of("type").unwrap() {
         "avro" => jst::convert_avro(&data),
         "bigquery" => jst::convert_bigquery(&data),
-        _ => panic!(),
+        _ => panic!("Unknown type!"),
     };
     let pretty = serde_json::to_string_pretty(&output).unwrap();
     println!("{}", pretty);

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
         .get_matches();
 
     let reader: Box<io::Read> = match matches.value_of("FILE") {
+        Some(path) if path == "-" => Box::new(io::stdin()),
         Some(path) => {
             let file = File::open(path).unwrap();
             Box::new(BufReader::new(file))


### PR DESCRIPTION
The changes the package name from `jsonschema_transpiler` to `jsonschema-transpiler`. The application now reads from stdin when no argument are provided or from a file when a positional argument is passed. This should make it easier to run the tool in bash via xargs and pipelining.

I've also updated the README to include some example usage that shows what the input and outputs look like.